### PR TITLE
Rework

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.24
 
     - name: Test
       run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fortnoxab/gohtmock
 
-go 1.18
+go 1.24
 
 require github.com/stretchr/testify v1.8.0
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -59,7 +59,7 @@ func TestMockMultipleResponseAndCallbacks(t *testing.T) {
 
 func TestMockResponder(t *testing.T) {
 	mock := New()
-	mock.MockResponder("/test", func(w http.ResponseWriter, r *http.Request) {
+	mock.MockFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok"))
 	})
@@ -75,7 +75,7 @@ func TestMockResponder(t *testing.T) {
 func TestMockResponderWithFilters(t *testing.T) {
 	mock := New()
 	// Should trigger for query id 1
-	mock.MockResponder("/test", func(w http.ResponseWriter, r *http.Request) {
+	mock.MockFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("user 1"))
 	}).Filter(func(r *http.Request) bool {
@@ -83,13 +83,13 @@ func TestMockResponderWithFilters(t *testing.T) {
 	})
 
 	// Should trigger as default fallback
-	mock.MockResponder("/test", func(w http.ResponseWriter, r *http.Request) {
+	mock.MockFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("user not found"))
 	})
 
 	// Should trigger for query id 2
-	mock.MockResponder("/test", func(w http.ResponseWriter, r *http.Request) {
+	mock.MockFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("user 2"))
 	}).Filter(func(r *http.Request) bool {
@@ -99,6 +99,57 @@ func TestMockResponderWithFilters(t *testing.T) {
 	assertGetResults(t, mock.URL()+"/test?id=1", "user 1", http.StatusOK)
 	assertGetResults(t, mock.URL()+"/test?id=3", "user not found", http.StatusNotFound)
 	assertGetResults(t, mock.URL()+"/test?id=2", "user 2", http.StatusOK)
+	mock.AssertCallCount(t, http.MethodGet, "/test", 3)
+	mock.AssertCallCountAsserted(t)
+}
+
+func TestMockResponderWithFiltersAsserts(t *testing.T) {
+	mock := New()
+	// Should trigger for query id 2
+	mr3 := mock.MockFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("user 2"))
+	}).Filter(func(r *http.Request) bool {
+		return r.URL.Query().Get("id") == "2"
+	})
+
+	// Should trigger for query id 1
+	mr1 := mock.MockFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("user 1"))
+	}).Filter(func(r *http.Request) bool {
+		return r.URL.Query().Get("id") == "1"
+	})
+
+	// Should trigger as default fallback
+	mr2 := mock.MockFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("user not found"))
+	})
+
+	assertGetResults(t, mock.URL()+"/test?id=1", "user 1", http.StatusOK)
+	assertGetResults(t, mock.URL()+"/test?id=3", "user not found", http.StatusNotFound)
+	assertGetResults(t, mock.URL()+"/test?id=2", "user 2", http.StatusOK)
+	mr1.AssertCallCount(t, 1)
+	mr2.AssertCallCount(t, 1)
+	mr3.AssertCallCount(t, 1)
+	mock.AssertCallCountAsserted(t)
+	mock.AssertNoMissingMocks(t)
+	mock.AssertMocksCalled(t)
+}
+
+func TestAllMocksLimits(t *testing.T) {
+	mock := New()
+	mock.Mock("/test", "once").Once()
+	mock.Mock("/test", "times").Times(2)
+
+	assertGetResults(t, mock.URL()+"/test", "once", http.StatusOK)
+	assertGetResults(t, mock.URL()+"/test", "times", http.StatusOK)
+	assertGetResults(t, mock.URL()+"/test", "times", http.StatusOK)
+	mock.AssertCallCount(t, "GET", "/test", 3)
+	mock.AssertCallCountAsserted(t)
+	mock.AssertNoMissingMocks(t)
+	mock.AssertMocksCalled(t)
 }
 
 func TestNotAssertCallCount(t *testing.T) {


### PR DESCRIPTION
Features
- Add support for depleted mock responses and custom repsonder callback
- Add support for mock match limits before they are depleted

Inner workings
- Move state to mockResponse to keep it where it is relevant
- Add support for checking of mockResponse is depleted
- Handle all mockResponses with filter before others, keeping initial sort
  order otherwise
- Add support for adding mockResponse with responder callback instead of
  static response

Bugfix
- Fixed bug where multiple static mocks with callbacks caused index out
  of bounds

**No breaking changes**